### PR TITLE
Boost 1.82 migration

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -15,8 +15,6 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-libboost_devel:
-- '1.82'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 cdt_name:
 - cos6
 channel_sources:
@@ -17,9 +15,9 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libboost_devel:
+- '1.82'
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/migrations/boost_cpp_to_libboost.yaml
+++ b/.ci_support/migrations/boost_cpp_to_libboost.yaml
@@ -1,0 +1,20 @@
+migrator_ts: 1695775149
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+  commit_message: "Rebuild for libboost 1.82"
+  # limit the number of prs for ramp-up
+  pr_limit: 10
+libboost_devel:
+  - 1.82
+# This migration is matched with a piggy-back migrator
+# (see https://github.com/regro/cf-scripts/pull/1668)
+# that will replace boost-cpp with libboost-devel
+boost_cpp:
+  - 1.82
+# same for boost -> libboost-python-devel
+libboost_python_devel:
+  - 1.82
+boost:
+  - 1.82

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -13,8 +13,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '15'
-libboost_devel:
-- '1.82'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
-boost_cpp:
-- 1.78.0
 channel_sources:
 - conda-forge
 - conda-forge
@@ -15,11 +13,11 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '15'
+libboost_devel:
+- '1.82'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -12,8 +12,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '15'
-libboost_devel:
-- '1.82'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-boost_cpp:
-- 1.78.0
 channel_sources:
 - conda-forge
 - conda-forge
@@ -14,11 +12,11 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '15'
+libboost_devel:
+- '1.82'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -9,8 +9,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-libboost_devel:
-- '1.82'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 channel_sources:
 - conda-forge
 - conda-forge
@@ -11,9 +9,9 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libboost_devel:
+- '1.82'
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,10 +34,10 @@ outputs:
 
     test:
       commands:
-        - test -f ${PREFIX}/include/prrng.h                                 # [unix]
-        - test -f ${PREFIX}/lib/cmake/prrng/prrngConfig.cmake               # [unix]
-        - if not exist %LIBRARY_PREFIX%\include\prrng.h exit 1              # [win]
-        - if not exist %LIBRARY_PREFIX%\lib\cmake\prrngConfig.cmake exit 1  # [win]
+        - test -f ${PREFIX}/include/prrng.h                                       # [unix]
+        - test -f ${PREFIX}/lib/cmake/prrng/prrngConfig.cmake                     # [unix]
+        - if not exist %LIBRARY_PREFIX%\include\prrng.h exit 1                    # [win]
+        - if not exist %LIBRARY_PREFIX%\lib\cmake\prrng\prrngConfig.cmake exit 1  # [win]
 
   - name: python-prrng
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 638788b382af6de5779fe7605039731c23c85e551b3fb15c941dd231b0e5762f
 
 build:
-  number: 1
+  number: 2
 
 outputs:
 
@@ -27,10 +27,9 @@ outputs:
         - cmake
         - make  # [unix]
       host:
-        - boost-cpp
+        - libboost-devel
         - xtensor
       run:
-        - boost-cpp
         - xtensor
 
     test:
@@ -60,7 +59,7 @@ outputs:
         - make  # [unix]
         - ninja
       host:
-        - boost-cpp
+        - libboost-headers
         - numpy *
         - pip
         - pybind11

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,11 @@
-{% set org = "tdegeus" %}
-{% set name = "prrng" %}
 {% set version = "1.12.0" %}
 
 package:
-  name: {{ name|lower }}-split
+  name: prrng-split
   version: {{ version }}
 
 source:
-  url: https://github.com/{{ org }}/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://github.com/tdegeus/prrng/archive/v{{ version }}.tar.gz
   sha256: 638788b382af6de5779fe7605039731c23c85e551b3fb15c941dd231b0e5762f
 
 build:
@@ -15,7 +13,7 @@ build:
 
 outputs:
 
-  - name: {{ name|lower }}
+  - name: prrng
 
     script: install.sh  # [unix]
     script: install.bat  # [win]
@@ -37,12 +35,12 @@ outputs:
 
     test:
       commands:
-        - test -f ${PREFIX}/include/{{ name }}.h  # [unix]
-        - test -f ${PREFIX}/lib/cmake/{{ name }}/{{ name }}Config.cmake  # [unix]
-        - if exist %LIBRARY_PREFIX%\include\{{ name }}.h (exit 0) else (exit 1)  # [win]
-        - if exist %LIBRARY_PREFIX%\lib\cmake\{{ name }}Config.cmake (exit 0) else (exit 1)  # [win]
+        - test -f ${PREFIX}/include/prrng.h                                 # [unix]
+        - test -f ${PREFIX}/lib/cmake/prrng/prrngConfig.cmake               # [unix]
+        - if not exist %LIBRARY_PREFIX%\include\prrng.h exit 1              # [win]
+        - if not exist %LIBRARY_PREFIX%\lib\cmake\prrngConfig.cmake exit 1  # [win]
 
-  - name: python-{{ name|lower }}
+  - name: python-prrng
 
     script: install_python.sh  # [unix]
     script: install_python.bat  # [win]
@@ -78,22 +76,22 @@ outputs:
 
     test:
       imports:
-        - {{ name }}
+        - prrng
       commands:
         - pip check
-        - python -c "import {{ name }}; assert {{ name }}.version() == '{{ version }}'"
+        - python -c "import prrng; assert prrng.version() == '{{ version }}'"
       requires:
         - pip
 
 about:
-  home: https://github.com/{{ org }}/{{ name }}
+  home: https://github.com/tdegeus/prrng
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: Portable Reconstructible (Pseudo) Random Number Generator.
   description: Portable Reconstructible (Pseudo) Random Number Generator.
-  doc_url: https://{{ org }}.github.io/{{ name }}
-  dev_url: https://github.com/{{ org }}/{{ name }}
+  doc_url: https://tdegeus.github.io/prrng
+  dev_url: https://github.com/tdegeus/prrng
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ outputs:
         - cmake
         - make  # [unix]
       host:
-        - libboost-devel
+        - libboost-headers
         - xtensor
       run:
         - xtensor


### PR DESCRIPTION
This recipe contains some unnecessary templating (not like the library name can ever change), which also happened to break the migration bot logic (which depends on finding the output names verbatim).

This fixes the former and migrates manually.