### PR TITLE
Adding missing deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 638788b382af6de5779fe7605039731c23c85e551b3fb15c941dd231b0e5762f
 
 build:
-  number: 2
+  number: 3
 
 outputs:
 
@@ -30,6 +30,7 @@ outputs:
         - libboost-headers
         - xtensor
       run:
+        - libboost-headers
         - xtensor
 
     test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixes bug from https://github.com/conda-forge/prrng-feedstock/pull/53

@h-vetinari . Is this the correct deps if a downstream package needs to compile prrng that contains the boost deps?

Current, a downstream package (of the C++ feedstock) gets 
```
2023-10-02T17:16:04.3105203Z CMake Error at /home/conda/feedstock_root/build_artifacts/frictionqpotspringblock-split_1696266756011/_build_env/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
2023-10-02T17:16:04.3106071Z   Could NOT find Boost (missing: Boost_INCLUDE_DIR)
```
see https://github.com/conda-forge/frictionqpotspringblock-feedstock/pull/63